### PR TITLE
Revert "Bump djangorestframework-stubs[compatible-mypy] from 3.14.4 to 3.15.1"

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -11,7 +11,7 @@ mypy==1.6.1  # https://github.com/python/mypy
 django-stubs[compatible-mypy]==4.2.6  # https://github.com/typeddjango/django-stubs
 pytest==8.3.5  # https://github.com/pytest-dev/pytest
 pytest-sugar==1.0.0  # https://github.com/Frozenball/pytest-sugar
-djangorestframework-stubs[compatible-mypy]==3.15.1  # https://github.com/typeddjango/djangorestframework-stubs
+djangorestframework-stubs[compatible-mypy]==3.14.4  # https://github.com/typeddjango/djangorestframework-stubs
 
 # Documentation
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Reverts animemoeus/mono-backend#422

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency version for djangorestframework-stubs in the local requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->