### PR TITLE
Bump django-unfold version to 0.59.0 in requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -53,4 +53,4 @@ django-health-check==3.18.3 # https://github.com/revsys/django-health-check
 saiyaku==2023.12.11 #  https://github.com/animemoeus/saiyaku
 openai==1.68.2 #  https://pypi.org/project/openai/
 
-django-unfold==0.58.0  # https://pypi.org/project/django-unfold/
+django-unfold==0.59.0  # https://pypi.org/project/django-unfold/

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -37,5 +37,3 @@ django-debug-toolbar==5.1.0  # https://github.com/jazzband/django-debug-toolbar
 django-extensions==3.2.3  # https://github.com/django-extensions/django-extensions
 django-coverage-plugin==3.1.0  # https://github.com/nedbat/django_coverage_plugin
 pytest-django==4.10.0  # https://github.com/pytest-dev/pytest-django
-
-django-unfold==0.58.0  # https://pypi.org/project/django-unfold/


### PR DESCRIPTION
# Description

This pull request updates the version of `django-unfold` in the project dependencies and removes a redundant entry for it in the local requirements file.

Dependency updates:

* Updated `django-unfold` from version `0.58.0` to `0.59.0` in `requirements/base.txt` to ensure the project uses the latest features and fixes.

Cleanup:

* Removed a duplicate entry for `django-unfold` in `requirements/local.txt`, as it is already specified in the base requirements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded the django-unfold package to version 0.59.0.
  - Removed the django-unfold dependency from the local requirements list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->