### PR TITLE
Update Twitter Video Downloader Safelink

### DIFF
--- a/twitter_downloader/models.py
+++ b/twitter_downloader/models.py
@@ -4,7 +4,6 @@ import uuid
 import requests
 from django.conf import settings
 from django.db import models
-from django.urls import reverse
 from solo.models import SingletonModel
 
 from models.base import BaseTelegramUserModel
@@ -169,10 +168,7 @@ class DownloadedTweet(models.Model):
         return self.tweet_url
 
     def send_to_telegram_user(self) -> bool:
-        url = f"https://api.animemoe.us{reverse('twitter-downloader:safelink')}?key={str(self.uuid)}"
-        result = self.telegram_user.send_download_button_with_safelink("🔰 DOWNLOAD 🔰", url)
-
-        return result
+        return self.telegram_user.send_video(self.tweet_data)
 
 
 class ExternalLink(models.Model):

--- a/twitter_downloader/models.py
+++ b/twitter_downloader/models.py
@@ -36,7 +36,10 @@ class TelegramUser(BaseTelegramUserModel):
                 "has_spoiler": message.get("is_nsfw", False),
                 "reply_markup": {
                     "inline_keyboard": [
-                        [{"text": f"🔗 {video['size']}", "url": video["url"]} for video in message.get("videos")[:3]],
+                        [
+                            {"text": f"🔗 {video['quality']}", "url": video["url"]}
+                            for video in message.get("videos", [])[:3]
+                        ],
                     ]
                 },
             }
@@ -73,8 +76,8 @@ class TelegramUser(BaseTelegramUserModel):
                 "reply_markup": {
                     "inline_keyboard": [
                         [
-                            {"text": f"🔗 {video['size']}", "url": video["url"]}
-                            for video in tweet_data.get("videos")[:3]
+                            {"text": f"🔗 {video['quality']}", "url": video["url"]}
+                            for video in tweet_data.get("videos", [])[:3]
                         ],
                     ]
                     + external_link

--- a/twitter_downloader/utils.py
+++ b/twitter_downloader/utils.py
@@ -450,7 +450,6 @@ class TwitterDownloaderAPIV4:
                 headers=headers,
                 timeout=30,
             )
-            print("++++++arter", response.status_code, response.text)
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             logger.error(f"Network error when connecting to Twitter API v4: {str(e)}")

--- a/twitter_downloader/views.py
+++ b/twitter_downloader/views.py
@@ -32,12 +32,12 @@ class SafelinkView(View):
         tweet_data = tweet.tweet_data
 
         videos = tweet_data.get("videos", [])
-        for video in videos:
+        if videos:
             tweet.telegram_user.send_video(
                 {
                     "description": tweet_data.get("text", ""),
-                    "videos": video.get("variants", []),
-                    "thumbnail": video.get("thumbnail"),
+                    "videos": videos,
+                    "thumbnail": tweet_data.get("thumbnail"),
                     "is_nsfw": tweet_data.get("is_nsfw"),
                 }
             )


### PR DESCRIPTION
This pull request updates how video download buttons are displayed and sent to Telegram users, improves code robustness, and simplifies some function calls. The main changes involve switching the video button label from file size to quality, ensuring safer handling of missing data, and streamlining the Telegram sending logic.

**Telegram message improvements:**

* Video download buttons now display the video's quality (e.g., "720p") instead of the file size in both `send_photo` and `send_video` methods. [[1]](diffhunk://#diff-a1e05bfc230e5e0e53b7f7e5174c4ccedeef8a5470fddff6bdebccd8e5de3252L39-R41) [[2]](diffhunk://#diff-a1e05bfc230e5e0e53b7f7e5174c4ccedeef8a5470fddff6bdebccd8e5de3252L76-R79)
* The code now safely handles cases where the `videos` list might be missing by defaulting to an empty list when building inline keyboards. [[1]](diffhunk://#diff-a1e05bfc230e5e0e53b7f7e5174c4ccedeef8a5470fddff6bdebccd8e5de3252L39-R41) [[2]](diffhunk://#diff-a1e05bfc230e5e0e53b7f7e5174c4ccedeef8a5470fddff6bdebccd8e5de3252L76-R79)

**Code simplification and robustness:**

* The `send_to_telegram_user` method now directly calls `send_video` with the tweet data, removing the previous safelink button logic.
* In the view, the Telegram user is sent the entire `videos` list and the tweet's thumbnail, instead of iterating through each video and sending them individually.
* Removed a debug print statement from the Twitter API utility function for cleaner logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved robustness when handling missing videos to prevent errors.

* **Improvements**
  * Changed video information label from "size" to "quality" in Telegram interface.
  * Consolidated video delivery: videos are now sent in a single message instead of multiple separate messages.
  * Removed debug logging output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->