### PR TITLE
Update Tests & Clean The Code

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -110,7 +110,6 @@ LOCAL_APPS = [
     # Your stuff: custom apps go here
     "cinematch",
     "discord",
-    "nz_store",
     "tiktok",
     "waifu",
     "twitter_downloader",

--- a/tiktok/tests/test_models.py
+++ b/tiktok/tests/test_models.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock, patch
+
 from django.test import TestCase
 
 from tiktok.models import User as TikTokUser
@@ -7,7 +9,39 @@ class TestTikTokUser(TestCase):
     def setUp(self):
         self.user = TikTokUser.objects.create(username="arter_tendean")
 
-    def test_update_data_from_api(self):
+    @patch("tiktok.models.requests.get")
+    @patch("tiktok.utils.requests.request")
+    def test_update_data_from_api(self, mock_request, mock_get):
+        expected_sec_uid = "MS4wLjABAAAAtest123"
+
+        # First call: get_user_id (fetch_user_profile)
+        mock_response_1 = Mock()
+        mock_response_1.ok = True
+        mock_response_1.json.return_value = {"data": {"userInfo": {"user": {"secUid": expected_sec_uid}}}}
+
+        # Second call: get_user_info (handler_user_profile)
+        mock_response_2 = Mock()
+        mock_response_2.ok = True
+        mock_response_2.json.return_value = {
+            "data": {
+                "user": {
+                    "nickname": "Arter Tendean",
+                    "unique_id": "arter_tendean",
+                    "avatar_larger": {"url_list": ["https://example.com/avatar.jpg"]},
+                    "follower_count": 100,
+                    "following_count": 50,
+                    "visible_videos_count": 10,
+                }
+            }
+        }
+
+        mock_request.side_effect = [mock_response_1, mock_response_2]
+
+        # Mock avatar download
+        mock_avatar_response = Mock()
+        mock_avatar_response.ok = False  # Skip actual file save
+        mock_get.return_value = mock_avatar_response
+
         self.user.update_data_from_api()
         self.assertNotEqual(self.user.user_id, "")
         self.assertNotEqual(self.user.avatar_url, "")

--- a/tiktok/tests/test_utils.py
+++ b/tiktok/tests/test_utils.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock, patch
+
 from django.test import TestCase
 
 from tiktok.utils import TikHubAPI
@@ -7,17 +9,61 @@ class TestTikHubAPI(TestCase):
     def setUp(self):
         self.tikhub = TikHubAPI()
 
-    def test__request(self):
+    @patch("tiktok.utils.requests.request")
+    def test__request(self, mock_request):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"data": {"userInfo": {"user": {"uniqueId": "tiktok"}}}}
+        mock_request.return_value = mock_response
+
         response = self.tikhub.request("/api/v1/tiktok/web/fetch_user_profile?uniqueId=tiktok")
         response_data = response.json().get("data")
 
         self.assertEqual(response.status_code, 200, "Should return 200 status code")
         self.assertIsNotNone(response_data, "Should not return empty data")
 
-    def test_get_user_id(self):
-        user_id = self.tikhub.get_user_id("aangiehsl")
-        self.assertEqual(user_id, "MS4wLjABAAAAPJwdzPJKzzNfqLlFTCqh4v8_zODCuUEbH4bNCELzegjPXmvN8pirTKmDo4wUzMVl")
+    @patch("tiktok.utils.requests.request")
+    def test_get_user_id(self, mock_request):
+        expected_sec_uid = "MS4wLjABAAAAPJwdzPJKzzNfqLlFTCqh4v8_zODCuUEbH4bNCELzegjPXmvN8pirTKmDo4wUzMVl"
+        mock_response = Mock()
+        mock_response.ok = True
+        mock_response.json.return_value = {"data": {"userInfo": {"user": {"secUid": expected_sec_uid}}}}
+        mock_request.return_value = mock_response
 
-    def test_get_user_info(self):
+        user_id = self.tikhub.get_user_id("aangiehsl")
+        self.assertEqual(user_id, expected_sec_uid)
+
+    @patch("tiktok.utils.requests.request")
+    def test_get_user_info(self, mock_request):
+        expected_sec_uid = "MS4wLjABAAAAPJwdzPJKzzNfqLlFTCqh4v8_zODCuUEbH4bNCELzegjPXmvN8pirTKmDo4wUzMVl"
+
+        # get_user_id response (fetch_user_profile)
+        mock_response_user_id = Mock()
+        mock_response_user_id.ok = True
+        mock_response_user_id.json.return_value = {"data": {"userInfo": {"user": {"secUid": expected_sec_uid}}}}
+
+        # get_user_info response (handler_user_profile)
+        mock_response_user_info = Mock()
+        mock_response_user_info.ok = True
+        mock_response_user_info.json.return_value = {
+            "data": {
+                "user": {
+                    "nickname": "Angie",
+                    "unique_id": "aangiehsl",
+                    "avatar_larger": {"url_list": ["https://example.com/avatar.jpg"]},
+                    "follower_count": 1000,
+                    "following_count": 500,
+                    "visible_videos_count": 50,
+                }
+            }
+        }
+
+        # Clear cache so get_user_id makes an API call
+        from django.core.cache import cache
+
+        cache.delete("tiktok_user_id_aangiehsl")
+
+        mock_request.side_effect = [mock_response_user_id, mock_response_user_info]
+
         user_info = self.tikhub.get_user_info("aangiehsl")
         self.assertEqual(user_info["username"], "aangiehsl", "Should return the correct username")

--- a/twitter_downloader/tests/test_models.py
+++ b/twitter_downloader/tests/test_models.py
@@ -37,7 +37,7 @@ class TestTelegramUserModel(TestCase):
         result = self.telegram_user.send_photo(
             {
                 "thumbnail": "https://avatars.githubusercontent.com/u/9919",
-                "videos": [{"url": "https://avatars.githubusercontent.com/u/9919", "size": 1337}],
+                "videos": [{"url": "https://avatars.githubusercontent.com/u/9919", "size": 1337, "quality": "HD"}],
             }
         )
         self.assertEqual(result, True, "Test send photo")
@@ -47,7 +47,7 @@ class TestTelegramUserModel(TestCase):
             {
                 "thumbnail": "https://avatars.githubusercontent.com/u/9919",
                 "description": "Test Send Video CI/CD",
-                "videos": [{"url": "https://link.testfile.org/aXCg7h", "size": 1337}],
+                "videos": [{"url": "https://link.testfile.org/aXCg7h", "size": 1337, "quality": "HD"}],
             }
         )
 
@@ -66,6 +66,7 @@ class TestTelegramUserModel(TestCase):
                     {
                         "url": "https://link.testfile.org/aYr11v",
                         "size": 1337,
+                        "quality": "HD",
                     }
                 ],
             }
@@ -97,16 +98,19 @@ class TestDownloadedTweet(TestCase):
                         "url": "https://video.twimg.com/ext_tw_video/1832089368489504771/pu/vid/avc1/576x1024/li7koJg-y38Gc__b.mp4?tag=12",
                         "size": "576x1024",
                         "bitrate": 2176000,
+                        "quality": "HD",
                     },
                     {
                         "url": "https://video.twimg.com/ext_tw_video/1832089368489504771/pu/vid/avc1/480x852/Fhx7X8Yz3m8dpOrs.mp4?tag=12",
                         "size": "480x852",
                         "bitrate": 950000,
+                        "quality": "SD",
                     },
                     {
                         "url": "https://video.twimg.com/ext_tw_video/1832089368489504771/pu/vid/avc1/320x568/56e7jjUqebophPbI.mp4?tag=12",
                         "size": "320x568",
                         "bitrate": 632000,
+                        "quality": "Low",
                     },
                 ],
                 "thumbnail": "https://pbs.twimg.com/ext_tw_video_thumb/1832089368489504771/pu/img/cGHHNJSF8wSp8Ygv.jpg",

--- a/twitter_downloader/tests/test_models.py
+++ b/twitter_downloader/tests/test_models.py
@@ -1,39 +1,50 @@
 import time
+from unittest.mock import Mock, patch
 
 from django.test import TestCase
 
 from twitter_downloader.models import DownloadedTweet, ExternalLink, Settings, TelegramUser
 
 
+def _mock_ok_response(*args, **kwargs):
+    mock_response = Mock()
+    mock_response.ok = True
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"ok": True}
+    return mock_response
+
+
+@patch("models.base.requests.request", side_effect=_mock_ok_response)
+@patch("twitter_downloader.models.requests.request", side_effect=_mock_ok_response)
 class TestTelegramUserModel(TestCase):
     def setUp(self):
         self.telegram_user = TelegramUser.objects.create(
             user_id="939376599", first_name="Arter", last_name="Tendean", username="artertendean"
         )
 
-    def test_send_chat_action(self):
+    def test_send_chat_action(self, mock_tw_request, mock_base_request):
         result = self.telegram_user.send_chat_action("typing")
         self.assertEqual(result, True, "Test send chat action")
 
-    def test_send_message(self):
+    def test_send_message(self, mock_tw_request, mock_base_request):
         result = self.telegram_user.send_message("Test Telegram user model")
         self.assertEqual(result, True)
 
-    def test_send_document(self):
+    def test_send_document(self, mock_tw_request, mock_base_request):
         result = self.telegram_user.send_document(
             "https://avatars.githubusercontent.com/u/9919", caption="Test document caption"
         )
         self.assertEqual(result, True)
 
-    def test_send_maintenance_message(self):
+    def test_send_maintenance_message(self, mock_tw_request, mock_base_request):
         result = self.telegram_user.send_maintenance_message()
         self.assertEqual(result, True, "Test maintenance message")
 
-    def test_send_banned_message(self):
+    def test_send_banned_message(self, mock_tw_request, mock_base_request):
         result = self.telegram_user.send_banned_message()
         self.assertEqual(result, True, "Test banned message")
 
-    def test_send_photo(self):
+    def test_send_photo(self, mock_tw_request, mock_base_request):
         result = self.telegram_user.send_photo(
             {
                 "thumbnail": "https://avatars.githubusercontent.com/u/9919",
@@ -42,7 +53,7 @@ class TestTelegramUserModel(TestCase):
         )
         self.assertEqual(result, True, "Test send photo")
 
-    def test_send_video(self):
+    def test_send_video(self, mock_tw_request, mock_base_request):
         result = self.telegram_user.send_video(
             {
                 "thumbnail": "https://avatars.githubusercontent.com/u/9919",
@@ -53,11 +64,11 @@ class TestTelegramUserModel(TestCase):
 
         self.assertEqual(result, True, "Test send video")
 
-    def test_send_download_button_with_safelink(self):
+    def test_send_download_button_with_safelink(self, mock_tw_request, mock_base_request):
         result = self.telegram_user.send_download_button_with_safelink("Arter Tendean", "https://animemoe.us")
         self.assertEqual(result, True, "Sould return 200 OK (True)")
 
-    def test_send_big_video(self):
+    def test_send_big_video(self, mock_tw_request, mock_base_request):
         result = self.telegram_user.send_video(
             {
                 "thumbnail": "https://avatars.githubusercontent.com/u/9919",
@@ -74,7 +85,7 @@ class TestTelegramUserModel(TestCase):
 
         self.assertEqual(result, True, "Test send video with big file size")
 
-    def test_image_with_inline_url(self):
+    def test_image_with_inline_url(self, mock_tw_request, mock_base_request):
         result = self.telegram_user.send_image_with_inline_keyboard(
             image_url="https://avatars.githubusercontent.com/u/9919",
             inline_text="Arter Tendean",
@@ -83,6 +94,8 @@ class TestTelegramUserModel(TestCase):
         self.assertEqual(result, True, "Test send image with inline url")
 
 
+@patch("models.base.requests.request", side_effect=_mock_ok_response)
+@patch("twitter_downloader.models.requests.request", side_effect=_mock_ok_response)
 class TestDownloadedTweet(TestCase):
     def setUp(self):
         self.telegram_user = TelegramUser.objects.create(
@@ -114,11 +127,11 @@ class TestDownloadedTweet(TestCase):
                     },
                 ],
                 "thumbnail": "https://pbs.twimg.com/ext_tw_video_thumb/1832089368489504771/pu/img/cGHHNJSF8wSp8Ygv.jpg",
-                "description": "I don’t understand how some people still hate cats😭😭 https://t.co/qTOc612wOX",
+                "description": "I don't understand how some people still hate cats😭😭 https://t.co/qTOc612wOX",
             },
         )
 
-    def test_sent_to_telegram_user(self):
+    def test_sent_to_telegram_user(self, mock_tw_request, mock_base_request):
         result = self.downloaded_tweet.send_to_telegram_user()
         self.assertEqual(result, True, "Should be able to send message")
 
@@ -132,8 +145,9 @@ class TestExternalLink(TestCase):
         self.assertEqual(queryset.count(), 1, "Should be able to get the external link data")
 
 
+@patch("twitter_downloader.models.requests.request", side_effect=_mock_ok_response)
 class TestSettings(TestCase):
-    def test_settings(self):
+    def test_settings(self, mock_request):
         settings = Settings.get_solo()
         settings.webhook_url = "https://api.animemoe.us"
         settings.save()

--- a/twitter_downloader/urls.py
+++ b/twitter_downloader/urls.py
@@ -1,15 +1,10 @@
 from django.urls import path
 
-from .views import SafelinkView, TelegramWebhookV2View, TelegramWebhookView, ValidateTelegramMiniAppDataView
+from .views import SafelinkView, TelegramWebhookView, ValidateTelegramMiniAppDataView
 
 urlpatterns = [
     path("safelink/", SafelinkView.as_view(), name="safelink"),
     path("telegram-webhook/", TelegramWebhookView.as_view(), name="telegram-webhook"),
-    path(
-        "telegram-webhook-v2/",
-        TelegramWebhookV2View.as_view(),
-        name="telegram-webhook-v2",
-    ),
     path(
         "telegram-webhook/validate-mini-app-data/",
         ValidateTelegramMiniAppDataView.as_view(),

--- a/twitter_downloader/views.py
+++ b/twitter_downloader/views.py
@@ -14,7 +14,7 @@ from .models import DownloadedTweet
 from .models import Settings as TwitterDownloaderSettings
 from .models import TelegramUser
 from .serializers import ValidateTelegramMiniAppDataSerializer
-from .utils import TwitterDownloaderAPIV2, TwitterDownloaderAPIV4, get_tweet_url
+from .utils import TwitterDownloaderAPIV4
 
 
 class SafelinkView(View):
@@ -182,98 +182,6 @@ class TelegramWebhookView(APIView):
         telegram_user.send_message(
             "Haha, I'm just a bot.\n\nI can't understand everything.\n\nTry sending a different command!"
         )
-
-
-class TelegramWebhookV2View(APIView):
-    def post(self, request):
-        telegram_webhook = TelegramWebhookParser(request.body)
-
-        try:
-            webhook_user = telegram_webhook.get_user()
-        except Exception as e:
-            return self._response_with_message(
-                f"Oops! There was an error: {str(e)}. Please try again.",
-                status.HTTP_400_BAD_REQUEST,
-            )
-
-        # Get or create Telegram User
-        telegram_user = self._get_or_create_telegram_user(webhook_user)
-        telegram_user.request_count += 1
-        telegram_user.save()
-
-        # Check for maintenance mode and return immediately if true
-        if self._is_maintenance_mode():
-            telegram_user.send_maintenance_message()
-            return self._response_with_message(
-                "Sorry! We're currently undergoing maintenance. Please check back later! 😝"
-            )
-
-        # Check if user is banned and return immediately if true
-        if telegram_user.is_banned:
-            telegram_user.send_banned_message()
-            return self._response_with_message(
-                "Uh-oh! Your account has been banned. Please contact support for assistance. ☠️"
-            )
-
-        # Handle text message if present
-        text_message = telegram_webhook.get_text_message()
-
-        if text_message:
-            self._handle_text_message(telegram_user, text_message)
-            return self._response_with_message(f"Got it! You've sent a text message: {text_message}")
-        else:
-            telegram_user.send_message("Hmmm 🤔")
-
-        return self._response_with_message("Hello from arter tendean! 😄")
-
-    def _get_or_create_telegram_user(self, webhook_user) -> TelegramUser:
-        # Helper method to get or create a Telegram user
-        telegram_user, _ = TelegramUser.objects.get_or_create(
-            user_id=webhook_user.get("id"),
-            defaults={
-                "first_name": webhook_user.get("first_name"),
-                "last_name": webhook_user.get("last_name"),
-                "username": webhook_user.get("username"),
-                "is_active": True,
-            },
-        )
-        return telegram_user
-
-    def _is_maintenance_mode(self) -> bool:
-        # Check if the system is in maintenance mode
-        return TwitterDownloaderSettings.get_solo().is_maintenance
-
-    def _handle_text_message(self, telegram_user: TelegramUser, message: str):
-        if message.startswith("/start"):
-            message = f"Hey <b>{telegram_user.first_name}</b>!\n\nWelcome to the <b>Twitter Video Downloader Bot</b>! 🎥📥\n\nI'm here to help you download videos from Twitter easily and quickly! 😄\n\n✨ Just send me a link to a Twitter video, and I’ll handle the rest! ✨"
-
-            telegram_user.send_message(message)
-
-        # Handle the text message that possibly contains tweet data
-        elif "https://x.com" in message.lower() or "https://twitter.com" in message.lower():
-            tweet_url = get_tweet_url(message.lower())
-            if not tweet_url:
-                telegram_user.send_message(
-                    "Hmm... I couldn't find a valid tweet URL in your message. Could you double-check it? 😊"
-                )
-
-            try:
-                twitter_downloader = TwitterDownloaderAPIV2(tweet_url=tweet_url)
-            except Exception as e:
-                telegram_user.send_message(str(e))
-                return
-
-            print(twitter_downloader)
-
-        else:
-            # Unknown text message
-            telegram_user.send_message(
-                "I'm not quite sure how to process that message. Can you try sending something different? 🤔"
-            )
-
-    def _response_with_message(self, message, status=status.HTTP_200_OK):
-        # Helper method to create a Response with a message
-        return Response({"message": message}, status=status)
 
 
 class ValidateTelegramMiniAppDataView(GenericAPIView):

--- a/waifu/tests/test_views.py
+++ b/waifu/tests/test_views.py
@@ -1,4 +1,5 @@
-import requests
+from unittest.mock import patch
+
 from django.test import TestCase
 from django.urls import reverse
 
@@ -33,43 +34,43 @@ def create_waifu_init_data():
     )
 
 
+@patch("waifu.views.refresh_serializer_data_urls", side_effect=lambda data: data)
 class TestWaifuListView(TestCase):
     def setUp(self):
         create_waifu_init_data()
 
-    def test_get_waifu_list(self):
+    def test_get_waifu_list(self, mock_refresh):
         self.assertEqual(Image.objects.all().count(), 2)
         response = self.client.get(reverse("waifu:index"))
         self.assertEqual(response.status_code, 200, "Should return 200 OK")
 
         data = response.json().get("results")[0]
-        response = requests.get(data.get("original_image"))
-        self.assertEqual(response.status_code, 200, "Should return 200 OK")
+        self.assertIn("original_image", data)
 
 
+@patch("waifu.views.refresh_serializer_data_urls", side_effect=lambda data: data)
 class TestWaifuDetailView(TestCase):
     def setUp(self):
         create_waifu_init_data()
 
-    def test_get_waifu_detail(self):
+    def test_get_waifu_detail(self, mock_refresh):
         self.assertEqual(Image.objects.all().count(), 2)
         response = self.client.get(reverse("waifu:detail", kwargs={"image_id": "1275631907933261897"}))
         self.assertEqual(response.status_code, 200, "Should return 200 OK")
 
         data = response.json()
-        response = requests.get(data.get("original_image"))
-        self.assertEqual(response.status_code, 200, "Should return 200 OK")
+        self.assertIn("original_image", data)
 
 
+@patch("waifu.views.refresh_serializer_data_urls", side_effect=lambda data: data)
 class TestRandomWaifuView(TestCase):
     def setUp(self):
         create_waifu_init_data()
 
-    def test_get_random_waifu(self):
+    def test_get_random_waifu(self, mock_refresh):
         self.assertEqual(Image.objects.all().count(), 2)
         response = self.client.get(reverse("waifu:random"))
         self.assertEqual(response.status_code, 200, "Should return 200 OK")
 
         data = response.json()
-        response = requests.get(data.get("original_image"))
-        self.assertEqual(response.status_code, 200, "Should return 200 OK")
+        self.assertIn("original_image", data)


### PR DESCRIPTION
This pull request focuses on improving test reliability and maintainability by replacing real HTTP requests with mocks across multiple test suites. Additionally, it removes an unused app from the project settings and cleans up the Twitter Downloader app by removing deprecated views and unused imports. The most important changes are grouped below:

**Testing improvements (mocking external requests):**

* Replaced real HTTP requests with `unittest.mock` in test files for `discord`, `tiktok`, `waifu`, and `twitter_downloader` apps, ensuring tests do not depend on external services and run faster and more reliably. [[1]](diffhunk://#diff-ff1bcd96426954b6bffe8e698a2f34576b6be196e25503f56074501590ca5439L1-R2) [[2]](diffhunk://#diff-0a0ac093518b65911443f3b0bb2d3f561ac205b2581a87b18570c6a21939a497R1-R2) [[3]](diffhunk://#diff-373a4a011b09bdb72e957076f95941323efba38111b7bcd7ce442b75ca57e7dfR1-R2) [[4]](diffhunk://#diff-18ee88847c5fd619489595684a82f908cbb5db1cc5af9f83f8ae24a96faa26bfL1-R2) [[5]](diffhunk://#diff-b169b601913f1777177cde321a668dd57c8578fbf114f5dbb8f3e1c67512c543L1-R2)
* Updated test logic to use mocks for API responses and avatar downloads in `tiktok/tests/test_models.py` and `tiktok/tests/test_utils.py`, allowing for more controlled and predictable test outcomes. [[1]](diffhunk://#diff-0a0ac093518b65911443f3b0bb2d3f561ac205b2581a87b18570c6a21939a497L10-R44) [[2]](diffhunk://#diff-373a4a011b09bdb72e957076f95941323efba38111b7bcd7ce442b75ca57e7dfL10-L21)
* Modified waifu test views to patch `refresh_serializer_data_urls`, preventing actual network calls and simplifying assertions.

**Project configuration cleanup:**

* Removed the unused `nz_store` app from the `INSTALLED_APPS` list in `config/settings/base.py`.

**Twitter Downloader app cleanup:**

* Removed the deprecated `TelegramWebhookV2View` and its route from `twitter_downloader/views.py` and `twitter_downloader/urls.py`, streamlining the codebase and eliminating unused endpoints. [[1]](diffhunk://#diff-f256372dcb2c6da0bbebd505e453af56f4a584ce28efb01269e6b123a48d28a1L3-L12) [[2]](diffhunk://#diff-d27c8f6630fe24df4f26256f848ced183f4d37f8dbb4bb588a80b543ff12f479L187-L278)
* Cleaned up imports in `twitter_downloader/views.py` by removing unused utilities and API classes.

**Test data enhancements:**

* Added `quality` attributes to video dictionaries in `twitter_downloader/tests/test_models.py` to improve test coverage and data accuracy. [[1]](diffhunk://#diff-10ca00c8288116391e049d63570dbb78197b271ad1c1f348ec4d6a6873eb0941L40-R40) [[2]](diffhunk://#diff-10ca00c8288116391e049d63570dbb78197b271ad1c1f348ec4d6a6873eb0941L50-R50) [[3]](diffhunk://#diff-10ca00c8288116391e049d63570dbb78197b271ad1c1f348ec4d6a6873eb0941R69) [[4]](diffhunk://#diff-10ca00c8288116391e049d63570dbb78197b271ad1c1f348ec4d6a6873eb0941R101-R113)

**Waifu utility test improvements:**

* Updated waifu utility tests to use mocks for refreshing URLs and serializer data, ensuring that tests verify refreshed URLs without making real HTTP requests. [[1]](diffhunk://#diff-18ee88847c5fd619489595684a82f908cbb5db1cc5af9f83f8ae24a96faa26bfL53-R66) [[2]](diffhunk://#diff-18ee88847c5fd619489595684a82f908cbb5db1cc5af9f83f8ae24a96faa26bfL88-R116)

These changes collectively improve the reliability, speed, and maintainability of the test suites and clean up unused code and configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the V2 telegram webhook endpoint (`telegram-webhook-v2/`) and associated functionality.
  * Removed an unused Django app from configuration.

* **Tests**
  * Refactored test suites across multiple modules to use mocking for external API calls instead of real HTTP requests, improving test reliability and speed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->